### PR TITLE
Fix models/image line 55

### DIFF
--- a/models/Image.php
+++ b/models/Image.php
@@ -52,7 +52,7 @@ class Image extends \yii\db\ActiveRecord
     public function getUrl($size = false){
         $urlSize = ($size) ? '_'.$size : '';
         $url = Url::toRoute([
-            '/'.$this->getPrimaryKey().'/images/image-by-item-and-alias',
+            '/'.$this->getModule()->id.'/images/image-by-item-and-alias',
             'item' => $this->modelName.$this->itemId,
             'dirtyAlias' =>  $this->urlAlias.$urlSize.'.'.$this->getExtension()
         ]);


### PR DESCRIPTION
I had a problem in the way getUrl(). The picture is not displayed and the address was using ID products. I changed in the method line on '/'.$this->getModule()->id.'/images/image-by-item-and-alias'
Thank you.