### PR TITLE
Fix issue #66

### DIFF
--- a/behaviors/ImageBehave.php
+++ b/behaviors/ImageBehave.php
@@ -50,9 +50,8 @@ class ImageBehave extends Behavior
         }
 
         $pictureFileName =
-            substr(md5(microtime(true) . $absolutePath), 4, 6)
-            . '.' .
-            pathinfo($absolutePath, PATHINFO_EXTENSION);
+            substr(md5(microtime(true) . $absolutePath), 4, 6) .
+            image_type_to_extension(getimagesize($absolutePath)[2]);
         $pictureSubDir = $this->getModule()->getModelSubDir($this->owner);
         $storePath = $this->getModule()->getStorePath($this->owner);
 


### PR DESCRIPTION
Attached image file may not have an extension. This situation often happens during uploading and storing files in /tmp directory. So the correct way is to get extension from file, not from path.