### PR TITLE
Fix for an issue that was reported on Github

### DIFF
--- a/models/Image.php
+++ b/models/Image.php
@@ -52,7 +52,7 @@ class Image extends \yii\db\ActiveRecord
     public function getUrl($size = false){
         $urlSize = ($size) ? '_'.$size : '';
         $url = Url::toRoute([
-            '/'.$this->getModule()->getPrimaryKey().'/images/image-by-item-and-alias',
+            '/'.$this->getModule()->id.'/images/image-by-item-and-alias',
             'item' => $this->modelName.$this->itemId,
             'dirtyAlias' =>  $this->urlAlias.$urlSize.'.'.$this->getExtension()
         ]);


### PR DESCRIPTION
Overzealous replacing of ->id led to the module name being removed from the createUrl call and replaced with the primary key of the object instead.